### PR TITLE
Sugar for universal type

### DIFF
--- a/ibis/demo.json
+++ b/ibis/demo.json
@@ -40,7 +40,7 @@
         ["p_de", "d", "read", "Serializable"],
         ["p_de", "e", "read", "number_or_string"],
         ["p_f", "f", "write", "ibis.ProductType(name: String, age: Int)"],
-        ["p_g", "g", "read", "name: ibis.UniversalType"],
+        ["p_g", "g", "read", "name: *"],
         ["p_h", "h", "read", "ibis.ProductType(name: String, age: Int)"],
         ["p_i", "i", "read", "name: String"],
         ["p_j", "j", "read", "age: Int"]

--- a/ibis/src/lib.rs
+++ b/ibis/src/lib.rs
@@ -53,14 +53,12 @@ macro_rules! apply {
 
 #[macro_export]
 macro_rules! is_a {
-    ($type: expr, $parent: expr) => {
-        {
-            use crate::type_parser::read_type;
-            let name = $type.name();
-            let ty = read_type(&name);
-            ty.name == $parent.name()
-        }
-    };
+    ($type: expr, $parent: expr) => {{
+        use crate::type_parser::read_type;
+        let name = $type.name();
+        let ty = read_type(&name);
+        ty.name == $parent.name()
+    }};
 }
 
 #[macro_export]

--- a/ibis/src/lib.rs
+++ b/ibis/src/lib.rs
@@ -54,7 +54,12 @@ macro_rules! apply {
 #[macro_export]
 macro_rules! is_a {
     ($type: expr, $parent: expr) => {
-        ($type.name().starts_with(&($parent.name() + "(")) && $type.name().ends_with(")"))
+        {
+            use crate::type_parser::read_type;
+            let name = $type.name();
+            let ty = read_type(&name);
+            ty.name == $parent.name()
+        }
     };
 }
 

--- a/ibis/src/type_parser.rs
+++ b/ibis/src/type_parser.rs
@@ -36,7 +36,10 @@ fn type_args(input: &str) -> IResult<&str, Vec<Type>> {
 }
 
 fn type_structure(input: &str) -> IResult<&str, Type> {
-    let (input, (name, args)) = tuple((name, opt(type_args)))(input)?;
+    let (input, (mut name, args)) = tuple((name, opt(type_args)))(input)?;
+    if name == "*" {
+        name = "ibis.UniversalType";
+    }
     Ok((input, Type::new(name, args.unwrap_or_default())))
 }
 

--- a/ibis/src/type_struct.rs
+++ b/ibis/src/type_struct.rs
@@ -46,7 +46,15 @@ impl<'a> std::fmt::Display for Type<'a> {
         // write!(f, "{}: ", self.args[0])?;
         // format_arg_set(f, " & ", &self.args[1..])
         } else {
-            let res = write!(f, "{}", self.name)?;
+            let res = write!(
+                f,
+                "{}",
+                if self.name == "ibis.UniversalType" {
+                    "*"
+                } else {
+                    self.name
+                }
+            )?;
             if self.args.is_empty() {
                 Ok(res)
             } else {


### PR DESCRIPTION
* Fixes is_a macro that was not set up to understand syntactic sugar
* Adds syntactic sugar for the UniversalType (also known as Top).