### PR TITLE
Prune_leakers

### DIFF
--- a/ibis/Cargo.lock
+++ b/ibis/Cargo.lock
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "crepe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a143ee68e4ec17aa70d0b95a1a5ef2c4e510b79cc3d956ea51bd2fe56d1856bd"
+checksum = "6d0c81f0055a7c877a9a69ec9d667a0b14c2b38394c712f54b9a400d035f49a9"
 dependencies = [
  "petgraph",
  "proc-macro-error",

--- a/ibis/Cargo.toml
+++ b/ibis/Cargo.toml
@@ -22,7 +22,7 @@ wasm = [ "wasm-bindgen", "console_error_panic_hook" ] # Support wasm-bindgen API
 [dependencies]
 nom = "7.1.0"
 paste = "1.0.6"
-crepe = "0.1.5"
+crepe = "0.1.6"
 lazy_static = "1.4.0"
 ibis_macros = { package = "arcsjs_ibis_macros", path = "./ibis_macros" }
 serde = { version = "1.0", features = ["derive"] }

--- a/ibis/src/recipes.rs
+++ b/ibis/src/recipes.rs
@@ -121,18 +121,18 @@ ibis! {
         LessPrivateThan(t1, t2),
         HasTag(s, source, n, t2); // Check failed, node has a 'more private' tag i.e. is leaking.
 
-    TypeError(s, from, from_ty, to, to_ty) <-
-        Node(_from_p, from, _, from_ty),
-        Node(_to_p, to, _, to_ty),
+    TypeError(s, *from, from_ty, *to, to_ty) <-
         Solution(s),
-        (s.has_edge(from, to)),
+        for (from, to) in &s.solution().edges,
+        Node(_from_p, *from, _, from_ty),
+        Node(_to_p, *to, _, to_ty),
         !Subtype(from_ty, to_ty); // Check failed, from writes an incompatible type into to
 
-    CapabilityError(s, from, from_capability, to, to_capability) <-
-        Node(_from_p, from, from_capability, _),
-        Node(_to_p, to, to_capability, _),
+    CapabilityError(s, *from, from_capability, *to, to_capability) <-
         Solution(s),
-        (s.has_edge(from, to)),
+        for (from, to) in &s.solution().edges,
+        Node(_from_p, *from, from_capability, _),
+        Node(_to_p, *to, to_capability, _),
         !Capability(from_capability, to_capability); // Check failed, from writes an incompatible type into to
 
     KnownType(x) <- Node(_par, _node, _cap, x); // Infer types that are used in the recipes.

--- a/ibis/src/recipes.rs
+++ b/ibis/src/recipes.rs
@@ -105,10 +105,10 @@ ibis! {
 
     HasTag(s, n, n, tag) <- Solution(s), Claim(n, tag);
     HasTag(s, source, down, tag) <- // Propagate tags 'downstream'
-        HasTag(s, source, curr, tag),
         Node(_down_particle, down, _, _),
-        (s.has_edge(curr, down)),
-        !TrustedToRemoveTag(down, tag);
+        HasTag(s, source, curr, tag),
+        !TrustedToRemoveTag(down, tag),
+        (s.has_edge(curr, down));
 
     HasTag(s, source, down, tag) <- // Propagate tags 'across stream' (i.e. inside a particle)
         HasTag(s, source, curr, tag),

--- a/ibis/src/recipes.rs
+++ b/ibis/src/recipes.rs
@@ -104,11 +104,11 @@ ibis! {
         KnownType(apply!(y_generic, y_arg));
 
     HasTag(s, n, n, tag) <- Solution(s), Claim(n, tag);
-    HasTag(s, source, down, tag) <- // Propagate tags 'downstream'
-        Node(_down_particle, down, _, _),
+    HasTag(s, source, *down, tag) <- // Propagate tags 'downstream'
         HasTag(s, source, curr, tag),
-        !TrustedToRemoveTag(down, tag),
-        (s.has_edge(curr, down));
+        for (up, down) in &s.solution().edges,
+        (*up == curr),
+        !TrustedToRemoveTag(*down, tag);
 
     HasTag(s, source, down, tag) <- // Propagate tags 'across stream' (i.e. inside a particle)
         HasTag(s, source, curr, tag),


### PR DESCRIPTION
Reorder checks and use edge ennumeration made possible in https://github.com/ekzhang/crepe/issues/17 for an expected performance improvement of -31%
