### PR TITLE
Fixes for to_dot impls

### DIFF
--- a/ibis/src/lib.rs
+++ b/ibis/src/lib.rs
@@ -16,9 +16,9 @@ mod type_struct;
 mod util;
 #[cfg(feature = "dot")]
 pub mod dot;
+pub mod recipes;
 #[cfg(feature = "dot")]
 pub mod to_dot_impls;
-pub mod recipes;
 extern crate ibis_macros;
 
 pub use ent::Ent;

--- a/ibis/src/lib.rs
+++ b/ibis/src/lib.rs
@@ -17,7 +17,7 @@ mod util;
 #[cfg(feature = "dot")]
 pub mod dot;
 #[cfg(feature = "dot")]
-pub mod recipe_to_dot;
+pub mod to_dot_impls;
 pub mod recipes;
 extern crate ibis_macros;
 


### PR DESCRIPTION
Moves to_dot impls into file named 'to_dot_impls' to make it more discoverable.
Also patches in changes to track changes in Ibis' output format.