### PR TITLE
Create benchmarks for useful idioms that Ibis uses

### DIFF
--- a/ibis/benches/all.rs
+++ b/ibis/benches/all.rs
@@ -4,20 +4,27 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-use criterion::{criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 mod checking_and_planning;
 mod checking_only;
 mod demo;
+mod utils;
 
 use checking_and_planning::*;
 use checking_only::*;
 use demo::*;
+use utils::*;
 
+criterion_group!(
+    name = micro_benches;
+    config = Criterion::default().sample_size(10000);
+    targets = criterion_benchmark_new_vec_push
+);
 criterion_group!(
     benches,
     criterion_benchmark_checking_only,
     criterion_benchmark_noop_planning,
     criterion_benchmark_solve_demo
 );
-criterion_main!(benches);
+criterion_main!(benches, micro_benches);

--- a/ibis/benches/utils.rs
+++ b/ibis/benches/utils.rs
@@ -19,11 +19,10 @@ fn concat(data1: &[u32], data2: u32) -> Vec<u32> {
 pub fn criterion_benchmark_new_vec_push(c: &mut Criterion) {
     let data1: Vec<u32> = (1..100000).into_iter().collect();
     let data2: u32 = 10001;
-    c.bench_function("noop_planning_vec_thing_mut", |b| b.iter(|| {
-        mut_push(black_box(&data1), black_box(data2))
-    }));
-    c.bench_function("noop_planning_vec_thing_concat", |b| b.iter(|| {
-        concat(black_box(&data1), black_box(data2))
-    }));
+    c.bench_function("noop_planning_vec_thing_mut", |b| {
+        b.iter(|| mut_push(black_box(&data1), black_box(data2)))
+    });
+    c.bench_function("noop_planning_vec_thing_concat", |b| {
+        b.iter(|| concat(black_box(&data1), black_box(data2)))
+    });
 }
-

--- a/ibis/benches/utils.rs
+++ b/ibis/benches/utils.rs
@@ -1,0 +1,29 @@
+// Copyright 2022 Google LLC
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+use criterion::{black_box, Criterion};
+
+fn mut_push(data1: &[u32], data2: u32) -> Vec<u32> {
+    let mut data = data1.to_vec();
+    data.push(data2);
+    data
+}
+
+fn concat(data1: &[u32], data2: u32) -> Vec<u32> {
+    [data1, &[data2]].concat()
+}
+
+pub fn criterion_benchmark_new_vec_push(c: &mut Criterion) {
+    let data1: Vec<u32> = (1..100000).into_iter().collect();
+    let data2: u32 = 10001;
+    c.bench_function("noop_planning_vec_thing_mut", |b| b.iter(|| {
+        mut_push(black_box(&data1), black_box(data2))
+    }));
+    c.bench_function("noop_planning_vec_thing_concat", |b| b.iter(|| {
+        concat(black_box(&data1), black_box(data2))
+    }));
+}
+


### PR DESCRIPTION
Recent refactors switched from
```rust
let mut data: Vec = some_slice.to_vec();
data.push(new_value);
```
to
```rust
let data = [some_slice, &[new_value]].concat();
```

The switch was simply for readability but I hadn't tested that these actually had the same runtime characteristics.

This PR adds a benchmark to check that they do actually perform similarly and finds that (at least on my machine) they perform equally well (modulo noise).

Adding this to the repo ensures that if we start seeing weird performance issues we can rule out a problem with this technique.