### PR TITLE
Introduce utility method for checking if a type subtypes another

### DIFF
--- a/ibis/checking.json
+++ b/ibis/checking.json
@@ -1,0 +1,36 @@
+{
+  "flags": {
+    "planning": false
+  },
+  "metadata": {
+    "author": "jopra@google.com",
+    "date": "2022/04/04"
+  },
+  "capabilities": [
+    ["write", "read"],
+    ["any", "read"],
+    ["write", "any"]
+  ],
+  "subtypes": [
+    ["Int", "Number"],
+    ["Int", "Serializable"],
+    ["String", "Serializable"]
+  ],
+  "less_private_than": [
+    ["public", "private"]
+  ],
+  "recipes": [
+    {
+      "metadata": {
+        "name": "checking_demo"
+      },
+      "nodes": [
+        ["p_a", "a", "write", "NotInt"],
+        ["p_b", "b", "read", "ibis.UnionType(Number, String)"]
+      ],
+      "edges": [
+        ["a", "b"]
+      ]
+    }
+  ]
+}

--- a/ibis/demo.json
+++ b/ibis/demo.json
@@ -4,7 +4,7 @@
   },
   "metadata": {
     "author": "jopra@google.com",
-    "date": "03/02/2020"
+    "date": "2022/02/03"
   },
   "capabilities": [
     ["write", "read"],

--- a/ibis/ibis.js
+++ b/ibis/ibis.js
@@ -83,6 +83,31 @@ function run(func, input) {
     }
 }
 
+export function check_is_subtype(subtype, supertype, subtypes) {
+    const input = {
+        flags: { planning: false },
+        subtypes,
+        capabilities: [
+            ["write", "read"]
+        ],
+        recipes: [
+            {
+                nodes: [
+                    ["p_a", "a", "write", subtype ],
+                    ["p_b", "b", "read", supertype ]
+                ],
+                edges: [
+                    ["a", "b"]
+                ]
+            }
+        ]
+    };
+    const result = JSON.parse(run(best_solutions_to_json_impl, [JSON.stringify(input)]));
+    const errors = result.recipes.map(recipe => recipe.type_errors) || []; // TODO: check for other kinds of errors.
+    logStatus(JSON.stringify('Found errors:', errors), 'error');
+    return errors.length === 0;
+}
+
 export function best_solutions_to_json(input) {
     return run(best_solutions_to_json_impl, input);
 }


### PR DESCRIPTION
Adds check_is_subtype a helper function to be used when pair-wise subtyping relationships are needed (in-place of whole graph checking).

Note: This check is not necessarily meaningful as without context, variables may resolve to types that contradict the resolutions necessary for the rest of the graph.