### PR TITLE
Parser cache

### DIFF
--- a/ibis/benches/all.rs
+++ b/ibis/benches/all.rs
@@ -18,7 +18,7 @@ use utils::*;
 
 criterion_group!(
     name = micro_benches;
-    config = Criterion::default().sample_size(10000);
+    config = Criterion::default().sample_size(1000);
     targets = criterion_benchmark_new_vec_push
 );
 criterion_group!(

--- a/ibis/src/context.rs
+++ b/ibis/src/context.rs
@@ -4,32 +4,36 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+use crate::type_struct::Type;
+
 use super::ent::*;
 use super::solution_data::SolutionData;
 use super::solution_id::*;
 use super::util::BiMap;
 use lazy_static::lazy_static;
-use std::cell::RefCell;
 #[cfg(feature = "ancestors")]
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Mutex;
+use std::{cell::RefCell, sync::Arc};
 
 pub struct Ctx {
     pub last_id: EntityIdBackingType,
     pub solution_id: SolutionIdBackingType,
     // TODO: Consider using https://docs.rs/bimap/latest/bimap/
-    pub id_to_name: BiMap<Ent, String>,
+    pub id_to_type: BiMap<Ent, Arc<Type>>,
     pub id_to_solution: BiMap<Sol, SolutionData>,
     #[cfg(feature = "ancestors")]
     pub ancestors: HashMap<Sol, BTreeSet<Sol>>,
 }
+
+impl Ctx {}
 
 impl Ctx {
     fn new() -> Self {
         Self {
             last_id: 0,
             solution_id: 0, // zero is never used except for the 'empty' solution
-            id_to_name: BiMap::new(),
+            id_to_type: BiMap::new(),
             id_to_solution: BiMap::new(),
             #[cfg(feature = "ancestors")]
             ancestors: HashMap::new(),

--- a/ibis/src/ent.rs
+++ b/ibis/src/ent.rs
@@ -55,7 +55,7 @@ impl Ent {
         let guard = CTX.lock().expect("Shouldn't fail");
         let mut ctx = (*guard).borrow_mut();
         // Normalize the names using the parser
-        let name = format!("{}", crate::type_parser::read_type(name));
+        let name = format!("{}", crate::type_parser_cache::read_type(name));
         Ent::get_by_name(&mut ctx, &name).unwrap_or_else(|| Ent::new(&mut ctx, &name))
     }
 }

--- a/ibis/src/ent.rs
+++ b/ibis/src/ent.rs
@@ -4,9 +4,11 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+use crate::{type_struct::Type, type_parser_cache::read_type};
+
 use super::context::{Ctx, CTX};
 use serde::{Deserialize, Serialize};
-use std::borrow::Borrow;
+use std::{borrow::Borrow, sync::Arc};
 
 pub type EntityIdBackingType = u64;
 
@@ -35,6 +37,11 @@ impl Ent {
         let ent = Ent { id };
         ctx.id_to_name.insert(ent, name.to_string());
         ent
+    }
+
+    pub fn get_type(&self) -> Arc<Type> {
+        let name = self.name();
+        read_type(&name)
     }
 
     pub fn name(&self) -> String {

--- a/ibis/src/ent.rs
+++ b/ibis/src/ent.rs
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-use crate::{type_struct::Type, type_parser_cache::read_type};
+use crate::{type_parser_cache::read_type, type_struct::Type};
 
 use super::context::{Ctx, CTX};
 use serde::{Deserialize, Serialize};
@@ -20,56 +20,50 @@ pub struct Ent {
 
 impl From<Ent> for String {
     fn from(ent: Ent) -> Self {
-        ent.name()
+        format!("{}", ent)
     }
 }
 
 impl From<String> for Ent {
     fn from(id: String) -> Self {
-        Self::by_name(&id)
+        let ty = read_type(&id);
+        Self::by_type(ty)
     }
 }
 
 impl Ent {
-    fn new(ctx: &mut Ctx, name: &str) -> Self {
+    fn new(ctx: &mut Ctx, ty: Arc<Type>) -> Self {
         let id = ctx.last_id;
         ctx.last_id += 1;
         let ent = Ent { id };
-        ctx.id_to_name.insert(ent, name.to_string());
+        ctx.id_to_type.insert(ent, ty);
         ent
     }
 
     pub fn get_type(&self) -> Arc<Type> {
-        let name = self.name();
-        read_type(&name)
-    }
-
-    pub fn name(&self) -> String {
         let guard = CTX.lock().expect("Shouldn't fail");
         let ctx = (*guard).borrow();
         ctx.borrow()
-            .id_to_name
+            .id_to_type
             .get(self)
             .cloned()
-            .expect("All entities should have a name")
+            .expect("All entities should have a type")
     }
 
-    fn get_by_name(ctx: &mut Ctx, name: &str) -> Option<Ent> {
-        ctx.id_to_name.get_back(name).cloned()
+    fn get_by_type(ctx: &mut Ctx, ty: &Type) -> Option<Ent> {
+        ctx.id_to_type.get_back(ty).cloned()
     }
 
-    pub fn by_name(name: &str) -> Ent {
+    pub fn by_type(ty: Arc<Type>) -> Ent {
         let guard = CTX.lock().expect("Shouldn't fail");
         let mut ctx = (*guard).borrow_mut();
-        // Normalize the names using the parser
-        let name = format!("{}", crate::type_parser_cache::read_type(name));
-        Ent::get_by_name(&mut ctx, &name).unwrap_or_else(|| Ent::new(&mut ctx, &name))
+        Ent::get_by_type(&mut ctx, &ty).unwrap_or_else(|| Ent::new(&mut ctx, ty))
     }
 }
 
 impl std::fmt::Display for Ent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.name())
+        write!(f, "{}", self.get_type())
     }
 }
 
@@ -77,7 +71,7 @@ impl std::fmt::Debug for Ent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Ent")
             .field("id", &self.id)
-            .field("{name}", &self.name())
+            .field("{repr}", &self.get_type())
             .finish()
     }
 }

--- a/ibis/src/lib.rs
+++ b/ibis/src/lib.rs
@@ -11,6 +11,7 @@ mod error;
 mod solution_data;
 mod solution_id;
 mod type_parser;
+mod type_parser_cache;
 mod type_struct;
 #[macro_use]
 mod util;
@@ -58,7 +59,7 @@ macro_rules! apply {
 #[macro_export]
 macro_rules! is_a {
     ($type: expr, $parent: expr) => {{
-        use crate::type_parser::read_type;
+        use crate::type_parser_cache::read_type;
         let name = $type.name();
         let ty = read_type(&name);
         ty.name == $parent.name() && !ty.args.is_empty()
@@ -68,7 +69,7 @@ macro_rules! is_a {
 #[macro_export]
 macro_rules! name {
     ($type: expr) => {{
-        use crate::type_parser::read_type;
+        use crate::type_parser_cache::read_type;
         let name = $type.name();
         let ty = read_type(&name);
         ent!(&format!("{}", ty.name))
@@ -78,7 +79,7 @@ macro_rules! name {
 #[macro_export]
 macro_rules! arg {
     ($type: expr, $ind: expr) => {{
-        use crate::type_parser::read_type;
+        use crate::type_parser_cache::read_type;
         let name = $type.name();
         let ty = read_type(&name);
         let ind = $ind;
@@ -92,11 +93,8 @@ macro_rules! arg {
 #[macro_export]
 macro_rules! args {
     ($type: expr) => {{
-        use crate::type_parser::read_type;
-        read_type(&$type.name())
-            .args
-            .iter()
-            .map(|arg| ent!(&format!("{}", arg)))
+        use crate::type_parser_cache::read_type;
+        read_type(&$type.name()).args.iter().map(|arg| ent!(&format!("{}", arg)))
     }};
 }
 

--- a/ibis/src/lib.rs
+++ b/ibis/src/lib.rs
@@ -59,19 +59,15 @@ macro_rules! apply {
 #[macro_export]
 macro_rules! is_a {
     ($type: expr, $parent: expr) => {{
-        use crate::type_parser_cache::read_type;
-        let name = $type.name();
-        let ty = read_type(&name);
-        ty.name == $parent.name() && !ty.args.is_empty()
+        let ty = $type.get_type();
+        ty.name == $parent.get_type().name && !ty.args.is_empty()
     }};
 }
 
 #[macro_export]
 macro_rules! name {
     ($type: expr) => {{
-        use crate::type_parser_cache::read_type;
-        let name = $type.name();
-        let ty = read_type(&name);
+        let ty = $type.get_type();
         ent!(&format!("{}", ty.name))
     }};
 }
@@ -79,12 +75,10 @@ macro_rules! name {
 #[macro_export]
 macro_rules! arg {
     ($type: expr, $ind: expr) => {{
-        use crate::type_parser_cache::read_type;
-        let name = $type.name();
-        let ty = read_type(&name);
+        let ty = $type.get_type();
         let ind = $ind;
         if ind >= ty.args.len() {
-            panic!("Cannot access argument {} of {}", ind, name);
+            panic!("Cannot access argument {} of {}", ind, ty);
         }
         ent!(&format!("{}", ty.args[ind]))
     }};

--- a/ibis/src/recipes.rs
+++ b/ibis/src/recipes.rs
@@ -33,25 +33,25 @@ ibis! {
 
     HasCapability(arg!(ty, 0), ty) <-
         KnownType(ty),
-        (is_a!(ty, ent!("ibis.WithCapability")));
+        (is_a!(ty, "ibis.WithCapability"));
 
     HasCapability(cap, ty) <-
         KnownType(ty),
-        (is_a!(ty, ent!("ibis.WithCapability"))),
+        (is_a!(ty, "ibis.WithCapability")),
         HasCapability(cap, arg!(ty, 1)); // Has all the child capabilities too.
 
     // Base case: just types.
     CompatibleWith(x, y) <-
         KnownType(x),
-        (!is_a!(x, ent!("ibis.WithCapability"))),
+        (!is_a!(x, "ibis.WithCapability")),
         KnownType(y),
-        (!is_a!(y, ent!("ibis.WithCapability"))),
+        (!is_a!(y, "ibis.WithCapability")),
         // ({eprintln!("checking subtyping ({}) ({})", x, y); true}),
         Subtype(x, y);
 
     CompatibleWith(x, y) <- // Check that y has the capabilities required by x.
         KnownType(x),
-        (is_a!(x, ent!("ibis.WithCapability"))),
+        (is_a!(x, "ibis.WithCapability")),
         KnownType(y),
         HasCapability(cap, y), // For each of the capabilities y supports
         // ({eprintln!("checking y has cap ({}) ({})", x, y); true}),
@@ -60,9 +60,9 @@ ibis! {
 
     CompatibleWith(x, y) <- // If a type has no capabilities, discard the capabilities of it's possible super type.
         KnownType(x),
-        (!is_a!(x, ent!("ibis.WithCapability"))),
+        (!is_a!(x, "ibis.WithCapability")),
         KnownType(y),
-        (is_a!(y, ent!("ibis.WithCapability"))),
+        (is_a!(y, "ibis.WithCapability")),
         // ({eprintln!("discarding capability from y ({}) ({})", x, y); true}),
         CompatibleWith(x, arg!(y, 1));
 
@@ -71,7 +71,7 @@ ibis! {
         prod
     ) <-
         KnownType(prod),
-        (is_a!(prod, ent!("ibis.ProductType"))),
+        (is_a!(prod, "ibis.ProductType")),
         KnownType(x),
         Subtype(x, arg!(prod, 0)),
         Subtype(x, arg!(prod, 1));
@@ -81,21 +81,21 @@ ibis! {
         arg!(prod, 0)
     ) <-
         KnownType(prod),
-        (is_a!(prod, ent!("ibis.ProductType")));
+        (is_a!(prod, "ibis.ProductType"));
 
     Subtype(
         prod,
         arg!(prod, 1)
     ) <-
         KnownType(prod),
-        (is_a!(prod, ent!("ibis.ProductType")));
+        (is_a!(prod, "ibis.ProductType"));
 
     Subtype(
         union_type,
         x
     ) <-
         KnownType(union_type),
-        (is_a!(union_type, ent!("ibis.UnionType"))),
+        (is_a!(union_type, "ibis.UnionType")),
         KnownType(x),
         Subtype(arg!(union_type, 0), x),
         Subtype(arg!(union_type, 1), x);
@@ -105,28 +105,28 @@ ibis! {
         union_type
     ) <-
         KnownType(union_type),
-        (is_a!(union_type, ent!("ibis.UnionType")));
+        (is_a!(union_type, "ibis.UnionType"));
 
     Subtype(
         arg!(union_type, 1),
         union_type
     ) <-
         KnownType(union_type),
-        (is_a!(union_type, ent!("ibis.UnionType")));
+        (is_a!(union_type, "ibis.UnionType"));
 
     Subtype(
         labelled,
         arg!(labelled, 1)
     ) <-
         KnownType(labelled),
-        (is_a!(labelled, ent!("ibis.Labelled")));
+        (is_a!(labelled, "ibis.Labelled"));
 
     Subtype(
         labelled,
-        apply!("ibis.Labelled", arg!(labelled, 0), sup)
+        apply!(ent!("ibis.Labelled"), arg!(labelled, 0), sup)
     ) <-
         KnownType(labelled),
-        (is_a!(labelled, ent!("ibis.Labelled"))),
+        (is_a!(labelled, "ibis.Labelled")),
         Subtype(arg!(labelled, 1), sup);
 
     Subtype(

--- a/ibis/src/type_parser.rs
+++ b/ibis/src/type_parser.rs
@@ -5,6 +5,7 @@
 // https://developers.google.com/open-source/licenses/bsd
 
 extern crate nom;
+use crate::type_struct::Type;
 use nom::{
     bytes::complete::{tag as simple_tag, take_while1},
     character::complete::{space0, space1},
@@ -13,7 +14,6 @@ use nom::{
     sequence::tuple,
     Finish, IResult,
 };
-use crate::type_struct::Type;
 
 fn is_name_char(c: char) -> bool {
     !matches!(

--- a/ibis/src/type_parser.rs
+++ b/ibis/src/type_parser.rs
@@ -6,7 +6,7 @@
 
 extern crate nom;
 use nom::{
-    bytes::complete::{tag, take_while1},
+    bytes::complete::{tag as simple_tag, take_while1},
     character::complete::{space0, space1},
     combinator::{cut, opt},
     multi::{separated_list0, separated_list1},
@@ -21,6 +21,13 @@ fn is_name_char(c: char) -> bool {
         c,
         '(' | ')' | '{' | '}' | ',' | ':' | ' ' | '\n' | '\r' | '\t'
     )
+}
+
+fn tag(exp: &'static str) -> impl Fn(&str) -> IResult<&str, &str> {
+    move |input| {
+        let (input, (_, s)) = tuple((space0, simple_tag(exp)))(input)?;
+        Ok((input, s))
+    }
 }
 
 fn is_lower_char(c: char) -> bool {
@@ -38,7 +45,7 @@ fn capability(input: &str) -> IResult<&str, &str> {
 }
 
 fn label(input: &str) -> IResult<&str, &str> {
-    let (input, (name, _, _)) = tuple((name, tag(":"), space0))(input)?;
+    let (input, (name, _)) = tuple((name, tag(":")))(input)?;
     Ok((input, name))
 }
 
@@ -52,15 +59,12 @@ fn type_args(input: &str) -> IResult<&str, Vec<Type>> {
 }
 
 fn parenthesized(input: &str) -> IResult<&str, Type> {
-    let (input, (_, _, ty, _)) = tuple((opt(space0), tag("("), cut(type_parser), tag(")")))(input)?;
+    let (input, (_, ty, _)) = tuple((tag("("), cut(type_parser), tag(")")))(input)?;
     Ok((input, ty))
 }
 
 fn simple_structure(input: &str) -> IResult<&str, Type> {
-    let (input, (mut name, args)) = tuple((name, opt(type_args)))(input)?;
-    if name == "*" {
-        name = "ibis.UniversalType";
-    }
+    let (input, (name, args)) = tuple((name, opt(type_args)))(input)?;
     Ok((input, Type::with_args(name, args.unwrap_or_default())))
 }
 
@@ -91,17 +95,18 @@ fn product_type(input: &str) -> IResult<&str, Type> {
 }
 
 fn structure_with_capability(input: &str) -> IResult<&str, Type> {
-    let (input, (cap, _, ty)) = tuple((capability, space0, cut(type_parser)))(input)?;
+    let (input, (cap, ty)) = tuple((capability, cut(type_parser)))(input)?;
     Ok((input, ty.with_capability(cap)))
 }
 
 fn type_parser(input: &str) -> IResult<&str, Type> {
-    let (input, _) = space0(input)?;
-    parenthesized(input)
+    let (input, res) = parenthesized(input)
         .or_else(|_| product_type(input))
         .or_else(|_| labelled_type(input))
         .or_else(|_| structure_with_capability(input))
-        .or_else(|_| simple_structure(input))
+        .or_else(|_| simple_structure(input))?;
+    let (input, _) = space0(input)?; // drop any following whitespace.
+    Ok((input, res))
 }
 
 pub fn read_type(og_input: &str) -> Type {

--- a/ibis/src/type_parser.rs
+++ b/ibis/src/type_parser.rs
@@ -13,7 +13,6 @@ use nom::{
     sequence::tuple,
     Finish, IResult,
 };
-
 use crate::type_struct::Type;
 
 fn is_name_char(c: char) -> bool {
@@ -109,7 +108,7 @@ fn type_parser(input: &str) -> IResult<&str, Type> {
     Ok((input, res))
 }
 
-pub fn read_type(og_input: &str) -> Type {
+pub fn read_type_uncached(og_input: &str) -> Type {
     // TODO: return errors instead of panics
     let (input, ty) = type_parser(og_input)
         .finish()
@@ -128,6 +127,8 @@ pub fn read_type(og_input: &str) -> Type {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use read_type_uncached as read_type;
 
     fn parse_and_round_trip(s: &str, t: Type) {
         let ty = read_type(s);

--- a/ibis/src/type_parser_cache.rs
+++ b/ibis/src/type_parser_cache.rs
@@ -7,20 +7,21 @@
 use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::cell::RefCell;
+use std::sync::Arc;
 use std::sync::Mutex;
 use std::borrow::BorrowMut;
 use crate::type_parser::read_type_uncached;
 use crate::type_struct::Type;
 
 lazy_static! {
-    pub static ref PARSE_CACHE: Mutex<RefCell<HashMap<String, Type>>> = Mutex::new(RefCell::new(HashMap::new()));
+    pub static ref PARSE_CACHE: Mutex<RefCell<HashMap<String, Arc<Type>>>> = Mutex::new(RefCell::new(HashMap::new()));
 }
-pub fn read_type(input: &str) -> Type {
+pub fn read_type(input: &str) -> Arc<Type> {
     let guard = PARSE_CACHE.lock().expect("Shouldn't fail");
     let mut ctx = (*guard).borrow_mut();
     ctx.borrow_mut()
         .entry(input.to_string())
-        .or_insert_with(|| read_type_uncached(input))
+        .or_insert_with(|| Arc::new(read_type_uncached(input)))
         .clone()
 }
 

--- a/ibis/src/type_parser_cache.rs
+++ b/ibis/src/type_parser_cache.rs
@@ -1,0 +1,26 @@
+// Copyright 2022 Google LLC
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+use std::cell::RefCell;
+use std::sync::Mutex;
+use std::borrow::BorrowMut;
+use crate::type_parser::read_type_uncached;
+use crate::type_struct::Type;
+
+lazy_static! {
+    pub static ref PARSE_CACHE: Mutex<RefCell<HashMap<String, Type>>> = Mutex::new(RefCell::new(HashMap::new()));
+}
+pub fn read_type(input: &str) -> Type {
+    let guard = PARSE_CACHE.lock().expect("Shouldn't fail");
+    let mut ctx = (*guard).borrow_mut();
+    ctx.borrow_mut()
+        .entry(input.to_string())
+        .or_insert_with(|| read_type_uncached(input))
+        .clone()
+}
+

--- a/ibis/src/type_parser_cache.rs
+++ b/ibis/src/type_parser_cache.rs
@@ -4,17 +4,18 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-use lazy_static::lazy_static;
-use std::collections::HashMap;
-use std::cell::RefCell;
-use std::sync::Arc;
-use std::sync::Mutex;
-use std::borrow::BorrowMut;
 use crate::type_parser::read_type_uncached;
 use crate::type_struct::Type;
+use lazy_static::lazy_static;
+use std::borrow::BorrowMut;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
 
 lazy_static! {
-    pub static ref PARSE_CACHE: Mutex<RefCell<HashMap<String, Arc<Type>>>> = Mutex::new(RefCell::new(HashMap::new()));
+    pub static ref PARSE_CACHE: Mutex<RefCell<HashMap<String, Arc<Type>>>> =
+        Mutex::new(RefCell::new(HashMap::new()));
 }
 pub fn read_type(input: &str) -> Arc<Type> {
     let guard = PARSE_CACHE.lock().expect("Shouldn't fail");
@@ -24,4 +25,3 @@ pub fn read_type(input: &str) -> Arc<Type> {
         .or_insert_with(|| Arc::new(read_type_uncached(input)))
         .clone()
 }
-

--- a/ibis/src/type_struct.rs
+++ b/ibis/src/type_struct.rs
@@ -15,7 +15,10 @@ impl Type {
         if name == "*" {
             name = "ibis.UniversalType";
         }
-        Self { name: name.to_string(), args }
+        Self {
+            name: name.to_string(),
+            args,
+        }
     }
     pub fn new(name: &str) -> Self {
         Self::with_args(name, vec![])

--- a/ibis/src/type_struct.rs
+++ b/ibis/src/type_struct.rs
@@ -5,33 +5,36 @@
 // https://developers.google.com/open-source/licenses/bsd
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct Type<'a> {
-    pub name: &'a str,
-    pub args: Vec<Type<'a>>,
+pub struct Type {
+    pub name: String,
+    pub args: Vec<Type>,
 }
 
-impl<'a> Type<'a> {
-    pub fn with_args(name: &'a str, args: Vec<Type<'a>>) -> Self {
-        Self { name, args }
+impl Type {
+    pub fn with_args(mut name: &str, args: Vec<Type>) -> Self {
+        if name == "*" {
+            name = "ibis.UniversalType";
+        }
+        Self { name: name.to_string(), args }
     }
-    pub fn new(name: &'a str) -> Self {
+    pub fn new(name: &str) -> Self {
         Self::with_args(name, vec![])
     }
-    pub fn with_arg(mut self, arg: Type<'a>) -> Self {
+    pub fn with_arg(mut self, arg: Type) -> Self {
         self.args.push(arg);
         self
     }
-    pub fn with_capability(self, cap: &'a str) -> Self {
+    pub fn with_capability(self, cap: &str) -> Self {
         Type::new("ibis.WithCapability")
             .with_arg(Type::new(cap))
             .with_arg(self)
     }
 }
 
-fn format_arg_set<'a>(
+fn format_arg_set(
     f: &mut std::fmt::Formatter<'_>,
     joiner: &str,
-    args: &[Type<'a>],
+    args: &[Type],
 ) -> std::fmt::Result {
     if let Some(first) = args.first() {
         write!(f, "{}", first)?;
@@ -42,7 +45,7 @@ fn format_arg_set<'a>(
     Ok(())
 }
 
-impl<'a> std::fmt::Display for Type<'a> {
+impl std::fmt::Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.name == "ibis.WithCapability" && self.args.len() > 1 {
             write!(f, "{} ", self.args[0])?;
@@ -75,7 +78,7 @@ impl<'a> std::fmt::Display for Type<'a> {
                 if self.name == "ibis.UniversalType" {
                     "*"
                 } else {
-                    self.name
+                    &self.name
                 }
             )?;
             if self.args.is_empty() {

--- a/ibis/tests/graphs.rs
+++ b/ibis/tests/graphs.rs
@@ -33,7 +33,7 @@ fn create_combinations() {
         &|recipe| {
             let mut in_nodes: Vec<String> = (&recipe.edges)
                 .iter()
-                .map(|(from, _to)| from.name())
+                .map(|(from, _to)| format!("{}", from.get_type()))
                 .collect();
             in_nodes.sort();
             in_nodes.join("")


### PR DESCRIPTION
Largely negates the performance regression caused by #70 (7x) and reduces perf regression to ~2x, assumed to be due to more complex checking work being done, and non-lazy type evaluation.