### PR TITLE
Clone avoidance

### DIFF
--- a/ibis/src/context.rs
+++ b/ibis/src/context.rs
@@ -21,7 +21,7 @@ pub struct Ctx {
     pub solution_id: SolutionIdBackingType,
     // TODO: Consider using https://docs.rs/bimap/latest/bimap/
     pub id_to_type: BiMap<Ent, Arc<Type>>,
-    pub id_to_solution: BiMap<Sol, SolutionData>,
+    pub id_to_solution: BiMap<Sol, Arc<SolutionData>>,
     #[cfg(feature = "ancestors")]
     pub ancestors: HashMap<Sol, BTreeSet<Sol>>,
 }

--- a/ibis/src/recipes.rs
+++ b/ibis/src/recipes.rs
@@ -342,19 +342,7 @@ impl From<&Recipe> for Sol {
 
 impl From<Sol> for Recipe {
     fn from(sol: Sol) -> Self {
-        let solution = sol.solution();
-        Recipe {
-            id: Some(sol),
-            feedback: Feedback::default(),
-            metadata: serde_json::Value::Null,
-            nodes: vec![],
-            claims: vec![],
-            checks: vec![],
-            trusted_to_remove_tag: vec![],
-            edges: make(&solution.edges, Clone::clone),
-            #[cfg(feature = "ancestors")]
-            ancestors: sol.ancestors().iter().cloned().collect(),
-        }
+        Recipe::from_sol(sol)
     }
 }
 
@@ -394,15 +382,15 @@ impl Ibis {
         runtime.extend(self.config.less_private_than.clone());
         runtime.extend(self.config.capabilities.clone());
 
-        let maybe_shared = if Sol::from(&self.shared) == Sol::default() {
+        let maybe_shared: Option<&Recipe> = if Sol::from(&self.shared) == Sol::default() {
             None
         } else {
-            Some(self.shared.clone())
+            Some(&self.shared)
         };
-        for recipe in self.recipes.iter().chain(maybe_shared.iter()) {
+        for recipe in self.recipes.iter().chain(maybe_shared) {
             // Add necessary data to this module and add a 'new solution'.
             let sol = Sol::from(recipe);
-            runtime.extend(vec![Seed(sol)]);
+            runtime.extend(&[Seed(sol)]);
         }
 
         for recipe in self.recipes.iter().chain(Some(self.shared.clone()).iter()) {

--- a/ibis/src/to_dot_impls.rs
+++ b/ibis/src/to_dot_impls.rs
@@ -121,7 +121,8 @@ impl ToDot for (&Ibis, &Recipe) {
             sol_graph.add_edge(node_id(from), node_id(to), vec![format!("style=dotted color=red label=<<font color=\"red\">expected '{}', found incompatible type '{}'</font>>", to_ty, from_ty)]);
         }
 
-        for (from_id, to_id) in &recipe.id.expect("WAT").edges() {
+        let sol = &recipe.id.expect("WAT").solution();
+        for (from_id, to_id) in &sol.edges {
             let from = format!("{}:s", node_id(from_id));
             let to = format!("{}:n", node_id(to_id));
             sol_graph.add_edge(from.clone(), to.clone(), vec![]);

--- a/ibis/src/type_struct.rs
+++ b/ibis/src/type_struct.rs
@@ -37,9 +37,7 @@ impl Type {
         self
     }
     pub fn with_capability(self, cap: &str) -> Self {
-        Type::new(WITH_CAPABILITY)
-            .with_arg(Type::new(cap))
-            .with_arg(self)
+        Self::new(WITH_CAPABILITY).with_args(vec![Type::new(cap), self])
     }
 }
 


### PR DESCRIPTION
Use drain and move instead of iter, clone and cloned to save a small amount of memory and time (up to 5%) 