### PR TITLE
File modes: Enables merging recipes and IR

### DIFF
--- a/ibis/playground/file-pane.js
+++ b/ibis/playground/file-pane.js
@@ -158,7 +158,7 @@ export class FilePane extends HTMLElement {
             tab.textContent = `${String.fromCharCode(this.fileBase++)}${this.ext || ''}`;
         }
         tab.linkedFile = file;
-        tab.addEventListener('click', this.showFile.bind(this))
+        tab.addEventListener('click', this.showFileOrRename.bind(this))
 
         this.tabs.appendChild(tab);
         this.files.appendChild(file);
@@ -201,6 +201,33 @@ export class FilePane extends HTMLElement {
             files[tab.textContent] = tab.linkedFile.value;
         }
         return files;
+    }
+
+    showFileOrRename(event) {
+        if (this.editmode) {
+            return;
+        }
+        const tab = event.target;
+        if (tab.classList.contains('active')) {
+            this.editmode = true;
+            const label = tab.innerText;
+            const edit_tab = document.createElement('input');
+            edit_tab.type = 'text';
+            edit_tab.value = label;
+            const done_button = document.createElement('input');
+            done_button.type = 'submit';
+            const form = document.createElement('form');
+            form.addEventListener('submit', (e) => {
+                e.preventDefault();
+                this.editmode = false;
+                tab.replaceChildren(edit_tab.value);
+                return false;
+            });
+            form.replaceChildren(edit_tab, done_button);
+            tab.replaceChildren(form);
+        } else {
+            this.showFile(event);
+        }
     }
 
     showFile(event) {

--- a/ibis/playground/index.html
+++ b/ibis/playground/index.html
@@ -12,7 +12,6 @@
     <h1>Ibis - Playground</h1>
     <div id="feedback">Waiting...</div>
     <input class="button" type="button" id="to_dot" value="Run"></input>
-    <input class="button" type="button" id="to_ir_then_dot" value="Ingest Recipes"></input>
     <input class="button" type="button" id="to_json" value="Debug"></input>
     <input class="button" type="button" id="share" value="Share"></input>
     <label for="add_file">

--- a/ibis/playground/playground.js
+++ b/ibis/playground/playground.js
@@ -162,7 +162,7 @@ async function setURIFromInputs() {
     }
     uri.searchParams.delete('i');
     uri.searchParams.delete('p'); // Avoid sharing local file paths.
-    for (let content of contents) {
+    for (let content of Object.values(contents)) {
         uri.searchParams.append('i', content);
     }
     window.history.pushState({},"", uri);

--- a/ibis/playground/playground.js
+++ b/ibis/playground/playground.js
@@ -52,7 +52,9 @@ async function getInputsFromURI() {
     // Read the inputs from the URI.
     const inputs = uri.searchParams && uri.searchParams.getAll('i') || [];
     for (let input of inputs) {
-        filePane.addFile(undefined, input);
+        let name = input.split('\n', 1)[0];
+        input = input.substr(name.length+1);
+        filePane.addFile(undefined, input, name);
     }
     const files = uri.searchParams && uri.searchParams.getAll('p') || [];
     for (let file of files) {
@@ -162,8 +164,8 @@ async function setURIFromInputs() {
     }
     uri.searchParams.delete('i');
     uri.searchParams.delete('p'); // Avoid sharing local file paths.
-    for (let content of Object.values(contents)) {
-        uri.searchParams.append('i', content);
+    for (let [name, content] of Object.entries(contents)) {
+        uri.searchParams.append('i', `${name}\n${content}`);
     }
     window.history.pushState({},"", uri);
 }

--- a/ibis/playground/playground.js
+++ b/ibis/playground/playground.js
@@ -72,24 +72,34 @@ async function startup() {
     const outputPaneDot = document.getElementById('outputPaneDot');
     const outputPaneJSON = document.getElementById('outputPaneJSON');
 
-    const to_json_callback = () => run(data => Object.values(data), best_solutions_to_json, json => {
+    const preprocessor = async (data) => {
+        console.log(data);
+        const files = [];
+        const recipes = {};
+        for (const [key, value] of Object.entries(data)) {
+            if (key.endsWith('.json')) { // Assume it is ibis IR.
+                files.push(value);
+            } else {
+                recipes[key] = value; // Keep it for conversion.
+            }
+        }
+        if (recipes !== {}) {
+            const output = await recipe_to_ir(recipes);
+            outputPaneJSON.addFile(undefined, output);
+            files.push(output);
+        }
+        return files;
+    };
+
+    const to_json_callback = () => run(preprocessor, best_solutions_to_json, json => {
         return JSON.stringify(JSON.parse(json), undefined, 2);
     }, outputPaneJSON);
     const to_json = document.getElementById('to_json');
     to_json.addEventListener("click", to_json_callback);
 
-    const to_dot_callback = () => run(data => Object.values(data), best_solutions_to_dot, noop, outputPaneDot);
+    const to_dot_callback = () => run(preprocessor, best_solutions_to_dot, noop, outputPaneDot);
     const to_dot = document.getElementById('to_dot');
     to_dot.addEventListener("click", to_dot_callback);
-
-    const recipe_to_ir_callback = async (data) => {
-        const output = await recipe_to_ir(data);
-        const outputFile = outputPaneJSON.addFile(undefined, output);
-        return output;
-    };
-    const to_ir_then_dot_callback = () => run(recipe_to_ir_callback, best_solutions_to_dot, noop, outputPaneDot);
-    const to_ir_then_dot = document.getElementById('to_ir_then_dot');
-    to_ir_then_dot.addEventListener("click", to_ir_then_dot_callback);
 
     const addFile = document.getElementById('add_file');
     addFile.addEventListener('change', async () => {


### PR DESCRIPTION
Improves the UI of the playground by parsing recipes based on their file name rather than having a different button for recipes vs IR.

This means that we can manually add IR to a set of recipes, smoothing over any issues in recipe parsing and further enhancing recipe exploration.