### PR TITLE
Flagging

### DIFF
--- a/ibis/src/lib.rs
+++ b/ibis/src/lib.rs
@@ -103,7 +103,7 @@ pub fn get_solutions(data: &str, loss: Option<usize>) -> Ibis {
             eprintln!("{}", data);
             e
         })
-        .unwrap_or_else(|_| panic!("JSON Error in {}", data));
+        .unwrap_or_else(|e| panic!("JSON Error: {}. In {}", e, data));
     runtime.add_recipes(recipes);
 
     runtime.extract_solutions_with_loss(loss)

--- a/ibis/src/recipes.rs
+++ b/ibis/src/recipes.rs
@@ -76,7 +76,7 @@ crepe! {
     #[derive(Debug, Ord, PartialOrd, Serialize, Deserialize)]
     pub struct TypeError(pub Sol, pub Ent, pub Ent, pub Ent, pub Ent); // sol, node, ty, source, ty
     UncheckedSolution(parent.add_edge(from, to)) <-
-        FlagEnabled("planning", true),
+        FlagEnabled(PLANNING, true),
         Node(_from_particle, from, from_type),
         Node(_to_particle, to, to_type),
         (from != to),
@@ -247,7 +247,8 @@ fn is_default<T: Default + Eq>(v: &T) -> bool {
     v == &T::default()
 }
 
-const FLAGS: &[&str] = &["planning"];
+const PLANNING: &str = "planning";
+const FLAGS: &[&str] = &[PLANNING];
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -448,7 +449,7 @@ impl Ibis {
         }
 
         let (solutions, unchecked_solutions, has_tags, leaks, type_errors) = runtime.run();
-        let recipes: Vec<Sol> = if let Some(true) = &self.config.flags.get("planning") {
+        let recipes: Vec<Sol> = if let Some(true) = &self.config.flags.get(PLANNING) {
             solutions.iter().map(|Solution(s)| *s).collect()
         } else {
             unchecked_solutions

--- a/ibis/src/recipes.rs
+++ b/ibis/src/recipes.rs
@@ -247,9 +247,7 @@ fn is_default<T: Default + Eq>(v: &T) -> bool {
     v == &T::default()
 }
 
-const FLAGS: &[&'static str] = &[
-    "planning",
-];
+const FLAGS: &[&str] = &["planning"];
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -401,9 +399,14 @@ impl Ibis {
         let mut warnings = Vec::new();
         for (key, value) in &self.config.flags {
             if let Some(flag) = FLAGS.iter().find(|flag| flag == &key) {
-                runtime.extend(&[FlagEnabled(&flag, *value)]);
+                runtime.extend(&[FlagEnabled(flag, *value)]);
             } else {
-                warnings.push(format!("Unknown flag {:?} set to: {:?}. Known flags are {}", key, value, FLAGS.join(", ")));
+                warnings.push(format!(
+                    "Unknown flag {:?} set to: {:?}. Known flags are {}",
+                    key,
+                    value,
+                    FLAGS.join(", ")
+                ));
             }
         }
         runtime.extend(self.config.subtypes.clone());
@@ -432,7 +435,7 @@ impl Ibis {
                 feedback: _,
                 metadata: _,
                 id: _,
-                edges: _, // To be captured by sol
+                edges: _,    // To be captured by sol
                 warnings: _, // These should be regenerated.
                 #[cfg(feature = "ancestors")]
                     ancestors: _,

--- a/ibis/tests/flags.rs
+++ b/ibis/tests/flags.rs
@@ -18,9 +18,18 @@ fn unknown_flag_generates_warning() {
 "#;
     let results: Ibis = get_solutions(data, None);
     assert_eq!(results.shared.warnings.len(), 1);
-    let warning = results.shared.warnings.get(0).expect("Should have a single value");
+    let warning = results
+        .shared
+        .warnings
+        .get(0)
+        .expect("Should have a single value");
     let expected = r#"Unknown flag "unknown_and_unexpected_flag" set to: true"#;
-    assert!(warning.starts_with(expected), "unexpected warning:\n'{}'\n'{}'", warning, expected);
+    assert!(
+        warning.starts_with(expected),
+        "unexpected warning:\n'{}'\n'{}'",
+        warning,
+        expected
+    );
 }
 
 #[test]

--- a/ibis/tests/flags.rs
+++ b/ibis/tests/flags.rs
@@ -1,0 +1,65 @@
+// Copyright 2022 Google LLC
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+use ibis::{get_solutions, Ibis};
+use pretty_assertions::assert_eq;
+
+#[test]
+fn unknown_flag_generates_warning() {
+    let data = r#"
+{
+    "flags": {
+        "unknown_and_unexpected_flag": true
+    }
+}
+"#;
+    let results: Ibis = get_solutions(data, None);
+    assert_eq!(results.shared.warnings.len(), 1);
+    let warning = results.shared.warnings.get(0).expect("Should have a single value");
+    let expected = r#"Unknown flag "unknown_and_unexpected_flag" set to: true"#;
+    assert!(warning.starts_with(expected), "unexpected warning:\n'{}'\n'{}'", warning, expected);
+}
+
+#[test]
+fn known_flags_round_trip_some_true() {
+    let data = r#"
+{
+    "flags": {
+        "planning": true
+    }
+}
+"#;
+    let results: Ibis = get_solutions(data, None);
+    assert_eq!(results.config.flags.get("planning"), Some(&true));
+    assert_eq!(results.shared.warnings, Vec::<&str>::new());
+}
+
+#[test]
+fn known_flags_round_trip_some_false() {
+    let data = r#"
+{
+    "flags": {
+        "planning": false
+    }
+}
+"#;
+    let results: Ibis = get_solutions(data, None);
+    assert_eq!(results.config.flags.get("planning"), Some(&false));
+    assert_eq!(results.shared.warnings, Vec::<&str>::new());
+}
+
+#[test]
+fn known_flags_round_trip_none() {
+    let data = r#"
+{
+    "flags": {
+    }
+}
+"#;
+    let results: Ibis = get_solutions(data, None);
+    assert_eq!(results.config.flags.get("planning"), None);
+    assert_eq!(results.shared.warnings, Vec::<&str>::new());
+}


### PR DESCRIPTION
Adds support for easily adding flags and using their (boolean) values in Crepe.

Also adds support for generating warnings in recipe handling code and exporting them via the shared recipe.