### PR TITLE
Multi arg products and unions

### DIFF
--- a/ibis/src/ent.rs
+++ b/ibis/src/ent.rs
@@ -50,13 +50,27 @@ impl Ent {
             .expect("All entities should have a type")
     }
 
+    pub fn is_a(&self, parent: &str) -> bool {
+        let ty = self.get_type();
+        ty.name == parent && !ty.args.is_empty()
+    }
+
+    pub fn args(&self) -> Vec<Ent> {
+        self.get_type().args.iter().map(|arg| Ent::by_type(arg.clone())).collect()
+    }
+
+    pub fn num_args(&self) -> usize {
+        self.get_type().args.len()
+    }
+
     fn get_by_type(ctx: &mut Ctx, ty: &Type) -> Option<Ent> {
         ctx.id_to_type.get_back(ty).cloned()
     }
 
-    pub fn by_type(ty: Arc<Type>) -> Ent {
+    pub fn by_type<T: Into<Arc<Type>>>(ty: T) -> Ent {
         let guard = CTX.lock().expect("Shouldn't fail");
         let mut ctx = (*guard).borrow_mut();
+        let ty = ty.into();
         Ent::get_by_type(&mut ctx, &ty).unwrap_or_else(|| Ent::new(&mut ctx, ty))
     }
 }

--- a/ibis/src/ent.rs
+++ b/ibis/src/ent.rs
@@ -56,7 +56,11 @@ impl Ent {
     }
 
     pub fn args(&self) -> Vec<Ent> {
-        self.get_type().args.iter().map(|arg| Ent::by_type(arg.clone())).collect()
+        self.get_type()
+            .args
+            .iter()
+            .map(|arg| Ent::by_type(arg.clone()))
+            .collect()
     }
 
     pub fn num_args(&self) -> usize {

--- a/ibis/src/lib.rs
+++ b/ibis/src/lib.rs
@@ -55,43 +55,11 @@ macro_rules! apply {
 }
 
 #[macro_export]
-macro_rules! is_a {
-    ($type: expr, $parent: expr) => {{
-        let ty = $type.get_type();
-        ty.name == $parent && !ty.args.is_empty()
-    }};
-}
-
-#[macro_export]
 macro_rules! name {
     ($type: expr) => {
         // TODO: remove this
         ent!(&$type.get_type().name)
     };
-}
-
-#[macro_export]
-macro_rules! arg {
-    ($type: expr, $ind: expr) => {{
-        let ty = $type.get_type();
-        let ind = $ind;
-        if ind >= ty.args.len() {
-            panic!("Cannot access argument {} of {}", ind, ty);
-        }
-        // Clones an Arc
-        Ent::by_type(ty.args[ind].clone())
-    }};
-}
-
-#[macro_export]
-macro_rules! args {
-    ($type: expr) => {{
-        $type
-            .get_type()
-            .args
-            .iter()
-            .map(|arg| Ent::by_type(arg.clone()))
-    }};
 }
 
 pub fn get_solutions(data: &str, loss: Option<usize>) -> Ibis {

--- a/ibis/src/recipes.rs
+++ b/ibis/src/recipes.rs
@@ -123,26 +123,26 @@ crepe! {
     // TODO: Replace with the 'all' aggregate when it exists.
     // See https://github.com/ekzhang/crepe/issues/10
     struct SubtypesAllArgs(Ent, Ent, usize);
-    SubtypesAllArgs(x, y, y.num_args()) <- KnownType(x), KnownType(y);
+    SubtypesAllArgs(x, y, 0) <- KnownType(x), KnownType(y);
     SubtypesAllArgs(x, y, n+1) <-
         SubtypesAllArgs(x, y, n),
-        (n+1 < y.num_args()),
-        Subtype(x, y.args()[n+1]);
+        (n < y.num_args()),
+        Subtype(x, y.args()[n]);
 
     // TODO: Replace with the 'all' aggregate when it exists.
     // See https://github.com/ekzhang/crepe/issues/10
     struct SupertypesAllArgs(Ent, Ent, usize);
-    SupertypesAllArgs(x, y, y.num_args()) <- KnownType(x), KnownType(y);
+    SupertypesAllArgs(x, y, 0) <- KnownType(x), KnownType(y);
     SupertypesAllArgs(x, y, n+1) <-
         SupertypesAllArgs(x, y, n),
-        (n+1 < y.num_args()),
-        Subtype(y.args()[n+1], x);
+        (n < y.num_args()),
+        Subtype(y.args()[n], x);
 
     Subtype(x, prod) <-
         KnownType(prod),
         (prod.is_a(PRODUCT)),
         KnownType(x),
-        SubtypesAllArgs(x, prod, 0);
+        SubtypesAllArgs(x, prod, prod.num_args());
 
     Subtype(
         prod,
@@ -159,7 +159,7 @@ crepe! {
         KnownType(union_type),
         (union_type.is_a(UNION)),
         KnownType(x),
-        SupertypesAllArgs(x, union_type, 0);
+        SupertypesAllArgs(x, union_type, union_type.num_args());
 
     Subtype(
         arg,

--- a/ibis/src/type_parser.rs
+++ b/ibis/src/type_parser.rs
@@ -169,6 +169,7 @@ pub trait TypeParser {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     struct TP;
 

--- a/ibis/src/type_parser.rs
+++ b/ibis/src/type_parser.rs
@@ -219,11 +219,13 @@ mod tests {
     fn read_a_product_type_using_syntactic_sugar() {
         let name_string = read_type("{name: String}");
         let age_number = read_type("{age: Number}");
+        let address_string = read_type("{address: String}");
         parse_and_round_trip(
-            "{name: String, age: Number}",
+            "{name: String, age: Number, address: String}",
             Type::new(PRODUCT)
                 .with_arg(name_string)
-                .with_arg(age_number),
+                .with_arg(age_number)
+                .with_arg(address_string),
         );
     }
 

--- a/ibis/tests/product_types.rs
+++ b/ibis/tests/product_types.rs
@@ -35,6 +35,36 @@ fn a_product_is_a_subtype_of_its_arguments() {
 }
 
 #[test]
+fn a_type_is_not_a_subtype_of_products_of_its_super_types_and_something_else() {
+    let solutions = all_edges(
+        r#"
+{
+  "flags": {
+    "planning": true
+  },
+  "capabilities": [
+    ["any", "any"]
+  ],
+  "subtypes": [
+    ["Man", "Mortal"],
+    ["Man", "Human"],
+    ["Socretes", "Man"]
+  ],
+  "recipes": [
+    {
+      "nodes": [
+        ["p_a", "a", "any {Mortal, Human, Man, Socretes, Dog}"],
+        ["p_b", "b", "any Socretes"]
+      ]
+    }
+  ]
+}"#,
+    );
+    let expected: Vec<String> = vec!["a -> b".to_string()];
+    assert_eq!(solutions, expected);
+}
+
+#[test]
 fn a_type_is_a_subtype_of_products_of_its_super_types() {
     let solutions = all_edges(
         r#"
@@ -47,19 +77,20 @@ fn a_type_is_a_subtype_of_products_of_its_super_types() {
   ],
   "subtypes": [
     ["Man", "Mortal"],
-    ["Man", "Human"]
+    ["Man", "Human"],
+    ["Socretes", "Man"]
   ],
   "recipes": [
     {
       "nodes": [
-        ["p_a", "a", "any {Human, Mortal}"],
-        ["p_b", "b", "any Man"]
+        ["p_a", "a", "any {Mortal, Human, Man, Socretes}"],
+        ["p_b", "b", "any Socretes"]
       ]
     }
   ]
 }"#,
     );
-    let expected: Vec<String> = vec!["b -> a".to_string()];
+    let expected: Vec<String> = vec!["a -> b, b -> a".to_string()];
     assert_eq!(solutions, expected);
 }
 

--- a/ibis/tests/union_types.rs
+++ b/ibis/tests/union_types.rs
@@ -35,6 +35,35 @@ fn a_union_is_a_subtype_of_its_arguments() {
 }
 
 #[test]
+fn a_union_is_not_a_subtype_of_its_arguments_with_unshared_super_types() {
+    let solutions = all_edges(
+        r#"
+{
+  "flags": {
+    "planning": true
+  },
+  "capabilities": [
+    ["any", "any"]
+  ],
+  "subtypes": [
+    ["TallMan", "Man"],
+    ["ShortMan", "Man"]
+  ],
+  "recipes": [
+    {
+      "nodes": [
+        ["p_a", "a", "any ibis.UnionType(TallMan, ShortMan, Dog)"],
+        ["p_b", "b", "any Man"]
+      ]
+    }
+  ]
+}"#,
+    );
+    let expected: Vec<String> = vec!["b -> a".to_string()];
+    assert_eq!(solutions, expected);
+}
+
+#[test]
 fn a_union_is_a_subtype_of_its_arguments_shared_super_types() {
     let solutions = all_edges(
         r#"
@@ -107,6 +136,37 @@ fn union_of_unions() {
       "nodes": [
         ["p_abc", "abc", "any ibis.UnionType(A, ibis.UnionType(B, C))"],
         ["p_acb", "acb", "any ibis.UnionType(ibis.UnionType(A, C), B)"],
+        ["p_a", "a", "any A"],
+        ["p_b", "b", "any B"],
+        ["p_c", "c", "any C"]
+      ]
+    }
+  ]
+}"#,
+    );
+    let expected: Vec<String> = vec![
+        "a -> abc, a -> acb, abc -> acb, acb -> abc, b -> abc, b -> acb, c -> abc, c -> acb"
+            .to_string(),
+    ];
+    assert_eq!(solutions, expected);
+}
+
+#[test]
+fn union_of_unions_inlined() {
+    let solutions = all_edges(
+        r#"
+{
+  "flags": {
+    "planning": true
+  },
+  "capabilities": [
+    ["any", "any"]
+  ],
+  "recipes": [
+    {
+      "nodes": [
+        ["p_abc", "abc", "any ibis.UnionType(A, B, C)"],
+        ["p_acb", "acb", "any ibis.UnionType(A, C, B)"],
         ["p_a", "a", "any A"],
         ["p_b", "b", "any B"],
         ["p_c", "c", "any C"]

--- a/ibis/tests/union_types.rs
+++ b/ibis/tests/union_types.rs
@@ -47,7 +47,8 @@ fn a_union_is_not_a_subtype_of_its_arguments_with_unshared_super_types() {
   ],
   "subtypes": [
     ["TallMan", "Man"],
-    ["ShortMan", "Man"]
+    ["ShortMan", "Man"],
+    ["Man", "ibis.UnionType(TallMan, ShortMan)"]
   ],
   "recipes": [
     {


### PR DESCRIPTION
Avoids previous limitation of where unions and products could only be formed 'piece-wise' i.e. union-ing and product-ing was a binary operator.

Now, many different types can be union'ed at once, which should reduce nesting of type structures and therefore the recursion depth needed to evaluate and compare types. 