### PR TITLE
Revert "Multi arg products and unions (#95)"

### DIFF
--- a/ibis/src/ent.rs
+++ b/ibis/src/ent.rs
@@ -50,31 +50,13 @@ impl Ent {
             .expect("All entities should have a type")
     }
 
-    pub fn is_a(&self, parent: &str) -> bool {
-        let ty = self.get_type();
-        ty.name == parent && !ty.args.is_empty()
-    }
-
-    pub fn args(&self) -> Vec<Ent> {
-        self.get_type()
-            .args
-            .iter()
-            .map(|arg| Ent::by_type(arg.clone()))
-            .collect()
-    }
-
-    pub fn num_args(&self) -> usize {
-        self.get_type().args.len()
-    }
-
     fn get_by_type(ctx: &mut Ctx, ty: &Type) -> Option<Ent> {
         ctx.id_to_type.get_back(ty).cloned()
     }
 
-    pub fn by_type<T: Into<Arc<Type>>>(ty: T) -> Ent {
+    pub fn by_type(ty: Arc<Type>) -> Ent {
         let guard = CTX.lock().expect("Shouldn't fail");
         let mut ctx = (*guard).borrow_mut();
-        let ty = ty.into();
         Ent::get_by_type(&mut ctx, &ty).unwrap_or_else(|| Ent::new(&mut ctx, ty))
     }
 }

--- a/ibis/src/lib.rs
+++ b/ibis/src/lib.rs
@@ -55,11 +55,43 @@ macro_rules! apply {
 }
 
 #[macro_export]
+macro_rules! is_a {
+    ($type: expr, $parent: expr) => {{
+        let ty = $type.get_type();
+        ty.name == $parent && !ty.args.is_empty()
+    }};
+}
+
+#[macro_export]
 macro_rules! name {
     ($type: expr) => {
         // TODO: remove this
         ent!(&$type.get_type().name)
     };
+}
+
+#[macro_export]
+macro_rules! arg {
+    ($type: expr, $ind: expr) => {{
+        let ty = $type.get_type();
+        let ind = $ind;
+        if ind >= ty.args.len() {
+            panic!("Cannot access argument {} of {}", ind, ty);
+        }
+        // Clones an Arc
+        Ent::by_type(ty.args[ind].clone())
+    }};
+}
+
+#[macro_export]
+macro_rules! args {
+    ($type: expr) => {{
+        $type
+            .get_type()
+            .args
+            .iter()
+            .map(|arg| Ent::by_type(arg.clone()))
+    }};
 }
 
 pub fn get_solutions(data: &str, loss: Option<usize>) -> Ibis {

--- a/ibis/src/type_parser.rs
+++ b/ibis/src/type_parser.rs
@@ -101,27 +101,27 @@ pub trait TypeParser {
         ))
     }
 
-    fn product_type<'a>(&mut self, og_input: &'a str) -> IResult<&'a str, Arc<Type>> {
+    fn product_type<'a>(&mut self, input: &'a str) -> IResult<&'a str, Arc<Type>> {
         let (input, (_, mut types, _)) = tuple((
             tag("{"),
             cut(separated_list1(tag(","), |i| self.type_parser(i))),
             tag("}"),
-        ))(og_input)?;
-        // Cannot store the incremental parses, as they are not directly from the 'source'.
-        if types.len() == 1 {
-            Ok((
-                input,
-                types.pop().expect("Types should have a single element"),
-            ))
-        } else {
-            let covered = &og_input[0..og_input.len() - input.len()];
-            Ok((
-                input,
-                self.store_type(covered, |s| {
-                    Arc::new((*s.type_from_name(PRODUCT)).clone().with_args(types))
-                }),
-            ))
+        ))(input)?;
+        let mut types: Vec<Arc<Type>> = types.drain(0..).rev().collect();
+        let mut ty = types
+            .pop()
+            .expect("A product type requires at least one type");
+        for new_ty in types {
+            // Cannot store the incremental parses, as they are not directly from the 'source'.
+            // TODO: Avoid needing nesting for a simple multi-product.
+            ty = Arc::new(
+                (*self.type_from_name(PRODUCT))
+                    .clone()
+                    .with_arg(ty)
+                    .with_arg(new_ty),
+            );
         }
+        Ok((input, ty))
     }
 
     fn structure_with_capability<'a>(&mut self, og_input: &'a str) -> IResult<&'a str, Arc<Type>> {
@@ -169,7 +169,6 @@ pub trait TypeParser {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pretty_assertions::assert_eq;
 
     struct TP;
 
@@ -220,13 +219,11 @@ mod tests {
     fn read_a_product_type_using_syntactic_sugar() {
         let name_string = read_type("{name: String}");
         let age_number = read_type("{age: Number}");
-        let address_string = read_type("{address: String}");
         parse_and_round_trip(
-            "{name: String, age: Number, address: String}",
+            "{name: String, age: Number}",
             Type::new(PRODUCT)
                 .with_arg(name_string)
-                .with_arg(age_number)
-                .with_arg(address_string),
+                .with_arg(age_number),
         );
     }
 

--- a/ibis/tests/product_types.rs
+++ b/ibis/tests/product_types.rs
@@ -35,36 +35,6 @@ fn a_product_is_a_subtype_of_its_arguments() {
 }
 
 #[test]
-fn a_type_is_not_a_subtype_of_products_of_its_super_types_and_something_else() {
-    let solutions = all_edges(
-        r#"
-{
-  "flags": {
-    "planning": true
-  },
-  "capabilities": [
-    ["any", "any"]
-  ],
-  "subtypes": [
-    ["Man", "Mortal"],
-    ["Man", "Human"],
-    ["Socretes", "Man"]
-  ],
-  "recipes": [
-    {
-      "nodes": [
-        ["p_a", "a", "any {Mortal, Human, Man, Socretes, Dog}"],
-        ["p_b", "b", "any Socretes"]
-      ]
-    }
-  ]
-}"#,
-    );
-    let expected: Vec<String> = vec!["a -> b".to_string()];
-    assert_eq!(solutions, expected);
-}
-
-#[test]
 fn a_type_is_a_subtype_of_products_of_its_super_types() {
     let solutions = all_edges(
         r#"
@@ -77,20 +47,19 @@ fn a_type_is_a_subtype_of_products_of_its_super_types() {
   ],
   "subtypes": [
     ["Man", "Mortal"],
-    ["Man", "Human"],
-    ["Socretes", "Man"]
+    ["Man", "Human"]
   ],
   "recipes": [
     {
       "nodes": [
-        ["p_a", "a", "any {Mortal, Human, Man, Socretes}"],
-        ["p_b", "b", "any Socretes"]
+        ["p_a", "a", "any {Human, Mortal}"],
+        ["p_b", "b", "any Man"]
       ]
     }
   ]
 }"#,
     );
-    let expected: Vec<String> = vec!["a -> b, b -> a".to_string()];
+    let expected: Vec<String> = vec!["b -> a".to_string()];
     assert_eq!(solutions, expected);
 }
 

--- a/ibis/tests/union_types.rs
+++ b/ibis/tests/union_types.rs
@@ -35,36 +35,6 @@ fn a_union_is_a_subtype_of_its_arguments() {
 }
 
 #[test]
-fn a_union_is_not_a_subtype_of_its_arguments_with_unshared_super_types() {
-    let solutions = all_edges(
-        r#"
-{
-  "flags": {
-    "planning": true
-  },
-  "capabilities": [
-    ["any", "any"]
-  ],
-  "subtypes": [
-    ["TallMan", "Man"],
-    ["ShortMan", "Man"],
-    ["Man", "ibis.UnionType(TallMan, ShortMan)"]
-  ],
-  "recipes": [
-    {
-      "nodes": [
-        ["p_a", "a", "any ibis.UnionType(TallMan, ShortMan, Dog)"],
-        ["p_b", "b", "any Man"]
-      ]
-    }
-  ]
-}"#,
-    );
-    let expected: Vec<String> = vec!["b -> a".to_string()];
-    assert_eq!(solutions, expected);
-}
-
-#[test]
 fn a_union_is_a_subtype_of_its_arguments_shared_super_types() {
     let solutions = all_edges(
         r#"
@@ -137,37 +107,6 @@ fn union_of_unions() {
       "nodes": [
         ["p_abc", "abc", "any ibis.UnionType(A, ibis.UnionType(B, C))"],
         ["p_acb", "acb", "any ibis.UnionType(ibis.UnionType(A, C), B)"],
-        ["p_a", "a", "any A"],
-        ["p_b", "b", "any B"],
-        ["p_c", "c", "any C"]
-      ]
-    }
-  ]
-}"#,
-    );
-    let expected: Vec<String> = vec![
-        "a -> abc, a -> acb, abc -> acb, acb -> abc, b -> abc, b -> acb, c -> abc, c -> acb"
-            .to_string(),
-    ];
-    assert_eq!(solutions, expected);
-}
-
-#[test]
-fn union_of_unions_inlined() {
-    let solutions = all_edges(
-        r#"
-{
-  "flags": {
-    "planning": true
-  },
-  "capabilities": [
-    ["any", "any"]
-  ],
-  "recipes": [
-    {
-      "nodes": [
-        ["p_abc", "abc", "any ibis.UnionType(A, B, C)"],
-        ["p_acb", "acb", "any ibis.UnionType(A, C, B)"],
         ["p_a", "a", "any A"],
         ["p_b", "b", "any B"],
         ["p_c", "c", "any C"]


### PR DESCRIPTION
This reverts commit #95.

After doing some profiling, it seems that the regression mentioned in #95 is partially due to the caching behavior of the reasoning system, as well as the extra locking that processing multi-args introduces. Until I can find a way to remove the locking behavior I can't see an easy way to improve the performance of this approach, and the API is not significantly better, so I'll revert the change.

