### PR TITLE
D3 prep work

### DIFF
--- a/ibis/Cargo.toml
+++ b/ibis/Cargo.toml
@@ -15,9 +15,10 @@ crate-type = ["cdylib", "rlib"]
 # rlib is for native
 
 [features]
-default = [ "dot", "wasm" ]
+default = [ "dot", "d3", "wasm" ]
 ancestors = [] # Support the tracking of ancestor solutions
 dot = [] # Support the generation of dot graphs (for debugging)
+d3 = [] # Support the generation of d3 graphs (for user interface)
 wasm = [ "wasm-bindgen", "console_error_panic_hook" ] # Support wasm-bindgen API
 
 [dependencies]

--- a/ibis/ibis.d.ts
+++ b/ibis/ibis.d.ts
@@ -14,4 +14,4 @@ export function check_is_subtype(
   supertype: string,
   subtypes: [string, string][]
 ): boolean;
-export function best_solutions(input: string): string;
+export function run_ibis(input: string): string;

--- a/ibis/ibis.d.ts
+++ b/ibis/ibis.d.ts
@@ -14,5 +14,4 @@ export function check_is_subtype(
   supertype: string,
   subtypes: [string, string][]
 ): boolean;
-export function best_solutions_to_json(input: string): string;
-export function best_solutions_to_dot(input: string): string;
+export function best_solutions(input: string): string;

--- a/ibis/ibis.js
+++ b/ibis/ibis.js
@@ -7,8 +7,7 @@
 import {
     default as ibis,
     version_info,
-    best_solutions_to_json as best_solutions_to_json_impl,
-    best_solutions_to_dot as best_solutions_to_dot_impl
+    best_solutions as best_solutions_impl,
 } from './pkg/ibis.js';
 
 let ibisStatusCallback = undefined;
@@ -102,16 +101,12 @@ export function check_is_subtype(subtype, supertype, subtypes) {
             }
         ]
     };
-    const result = JSON.parse(run(best_solutions_to_json_impl, [JSON.stringify(input)]));
+    const result = JSON.parse(run(best_solutions_impl, [JSON.stringify(input)]));
     const errors = result.recipes.map(recipe => recipe.type_errors) || []; // TODO: check for other kinds of errors.
     logStatus(JSON.stringify('Found errors:', errors), 'error');
     return errors.length === 0;
 }
 
-export function best_solutions_to_json(input) {
-    return run(best_solutions_to_json_impl, input);
-}
-
-export function best_solutions_to_dot(input) {
-    return run(best_solutions_to_dot_impl, input);
+export function best_solutions(input) {
+    return run(best_solutions_impl, input);
 }

--- a/ibis/ibis.js
+++ b/ibis/ibis.js
@@ -7,7 +7,7 @@
 import {
     default as ibis,
     version_info,
-    best_solutions as best_solutions_impl,
+    run_ibis as run_ibis_impl,
 } from './pkg/ibis.js';
 
 let ibisStatusCallback = undefined;
@@ -60,7 +60,7 @@ function merge_recipe(dest, new_recipe) {
 }
 
 
-export function best_solutions(input) {
+export function run_ibis(input) {
     try {
         logStatus(`Merging recipes...`);
         const inputData = {};
@@ -73,7 +73,7 @@ export function best_solutions(input) {
         const inputJSON = JSON.stringify(inputData);
         logStatus(`Running...`);
         const startTime = performance.now()
-        const result = best_solutions_impl(inputJSON);
+        const result = run_ibis_impl(inputJSON);
         const endTime = performance.now()
         logStatus(`Done in ${(endTime-startTime)/1000.0} seconds`);
         return result;
@@ -102,7 +102,7 @@ export function check_is_subtype(subtype, supertype, subtypes) {
             }
         ]
     };
-    const result = JSON.parse(best_solutions([JSON.stringify(input)]));
+    const result = JSON.parse(run_ibis([JSON.stringify(input)]));
     const errors = result.recipes.map(recipe => recipe.type_errors) || []; // TODO: check for other kinds of errors.
     logStatus(JSON.stringify('Found errors:', errors), 'error');
     return errors.length === 0;

--- a/ibis/ibis.js
+++ b/ibis/ibis.js
@@ -59,7 +59,8 @@ function merge_recipe(dest, new_recipe) {
     }
 }
 
-function run(func, input) {
+
+export function best_solutions(input) {
     try {
         logStatus(`Merging recipes...`);
         const inputData = {};
@@ -72,7 +73,7 @@ function run(func, input) {
         const inputJSON = JSON.stringify(inputData);
         logStatus(`Running...`);
         const startTime = performance.now()
-        const result = func(inputJSON);
+        const result = best_solutions_impl(inputJSON);
         const endTime = performance.now()
         logStatus(`Done in ${(endTime-startTime)/1000.0} seconds`);
         return result;
@@ -101,12 +102,8 @@ export function check_is_subtype(subtype, supertype, subtypes) {
             }
         ]
     };
-    const result = JSON.parse(run(best_solutions_impl, [JSON.stringify(input)]));
+    const result = JSON.parse(best_solutions([JSON.stringify(input)]));
     const errors = result.recipes.map(recipe => recipe.type_errors) || []; // TODO: check for other kinds of errors.
     logStatus(JSON.stringify('Found errors:', errors), 'error');
     return errors.length === 0;
-}
-
-export function best_solutions(input) {
-    return run(best_solutions_impl, input);
 }

--- a/ibis/playground/converter.js
+++ b/ibis/playground/converter.js
@@ -101,7 +101,6 @@ export async function recipe_to_ir(all_js) {
     }
 
     const all_ir = {
-        flags: { planning: false },
         subtypes: [
             ['any', 'read'],
             ['any', 'write'],

--- a/ibis/playground/index.html
+++ b/ibis/playground/index.html
@@ -15,8 +15,7 @@
       <div id="examples"></div>
     </div>
     <div id="feedback">Waiting...</div>
-    <input class="button" type="button" id="to_dot" value="Run"></input>
-    <input class="button" type="button" id="to_json" value="Debug"></input>
+    <input class="button" type="button" id="run" value="Run"></input>
     <input class="button" type="button" id="share" value="Share"></input>
     <label for="add_file">
       <span class="button">Upload local files</span>
@@ -25,6 +24,7 @@
     <file-pane id="filePane" ext=".json"></file-pane>
     <div id="graph" class="graph"></div>
       <file-pane id="outputPaneDot" name="Dot output" ext=".dot" no-add-button="true"></file-pane>
+      <file-pane id="outputPaneD3" name="D3 output" ext=".d3" no-add-button="true"></file-pane>
       <file-pane id="outputPaneJSON" name="JSON Output" ext=".json" no-add-button="true"></file-pane>
     <div id="version_info"></div>
     <div class="footer">

--- a/ibis/src/bin/dot.rs
+++ b/ibis/src/bin/dot.rs
@@ -15,7 +15,12 @@ fn main() -> Result<(), IbisError> {
         .read_to_string(&mut data)
         .expect("IO Error, reading stdin");
     eprintln!("Preparing graph...");
-    println!("{}", run_ibis(&data).dot_output.unwrap_or_else(||"Dot output not found".to_string()));
+    println!(
+        "{}",
+        run_ibis(&data)
+            .dot_output
+            .unwrap_or_else(|| "Dot output not found".to_string())
+    );
     Ok(())
 }
 

--- a/ibis/src/bin/dot.rs
+++ b/ibis/src/bin/dot.rs
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-use ibis::best_solutions;
+use ibis::run_ibis;
 use ibis::IbisError;
 use std::io::Read;
 
@@ -15,7 +15,7 @@ fn main() -> Result<(), IbisError> {
         .read_to_string(&mut data)
         .expect("IO Error, reading stdin");
     eprintln!("Preparing graph...");
-    println!("{}", best_solutions(&data).dot_output.unwrap_or_else(||"Dot output not found".to_string()));
+    println!("{}", run_ibis(&data).dot_output.unwrap_or_else(||"Dot output not found".to_string()));
     Ok(())
 }
 

--- a/ibis/src/bin/dot.rs
+++ b/ibis/src/bin/dot.rs
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-use ibis::best_solutions_to_dot;
+use ibis::best_solutions;
 use ibis::IbisError;
 use std::io::Read;
 
@@ -15,8 +15,7 @@ fn main() -> Result<(), IbisError> {
         .read_to_string(&mut data)
         .expect("IO Error, reading stdin");
     eprintln!("Preparing graph...");
-    #[cfg(feature = "dot")]
-    println!("{}", best_solutions_to_dot(&data));
+    println!("{}", best_solutions(&data).dot_output.unwrap_or_else(||"Dot output not found".to_string()));
     Ok(())
 }
 

--- a/ibis/src/bin/main.rs
+++ b/ibis/src/bin/main.rs
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-use ibis::best_solutions_to_json;
+use ibis::best_solutions;
 use ibis::IbisError;
 use std::io::Read;
 
@@ -15,7 +15,8 @@ fn main() -> Result<(), IbisError> {
         .read_to_string(&mut data)
         .expect("IO Error, reading stdin");
     eprintln!("Preparing graph...");
-    println!("{}", best_solutions_to_json(&data));
+    let solutions = best_solutions(&data);
+    println!("{}", serde_json::to_string(&solutions).expect("Couldn't serialize Ibis output"));
     Ok(())
 }
 

--- a/ibis/src/bin/main.rs
+++ b/ibis/src/bin/main.rs
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-use ibis::best_solutions;
+use ibis::run_ibis;
 use ibis::IbisError;
 use std::io::Read;
 
@@ -15,7 +15,7 @@ fn main() -> Result<(), IbisError> {
         .read_to_string(&mut data)
         .expect("IO Error, reading stdin");
     eprintln!("Preparing graph...");
-    let solutions = best_solutions(&data);
+    let solutions = run_ibis(&data);
     println!("{}", serde_json::to_string(&solutions).expect("Couldn't serialize Ibis output"));
     Ok(())
 }

--- a/ibis/src/bin/main.rs
+++ b/ibis/src/bin/main.rs
@@ -16,7 +16,10 @@ fn main() -> Result<(), IbisError> {
         .expect("IO Error, reading stdin");
     eprintln!("Preparing graph...");
     let solutions = run_ibis(&data);
-    println!("{}", serde_json::to_string(&solutions).expect("Couldn't serialize Ibis output"));
+    println!(
+        "{}",
+        serde_json::to_string(&solutions).expect("Couldn't serialize Ibis output")
+    );
     Ok(())
 }
 

--- a/ibis/src/d3.rs
+++ b/ibis/src/d3.rs
@@ -1,0 +1,40 @@
+// Copyright 2022 Google LLC
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+use serde::{Deserialize, Serialize};
+use crate::recipes::{Recipe, Ibis};
+
+#[derive(Default, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde()]
+pub struct D3Graph {
+    nodes: Vec<String>,
+    edges: Vec<(String, String, Vec<String>)>,
+}
+
+pub trait ToD3 {
+    fn to_d3(&self) -> D3Graph;
+}
+
+impl D3Graph {
+    pub fn add_node(&mut self, node: String) {
+        self.nodes.push(node);
+    }
+
+    pub fn add_edge(&mut self, from: String, to: String, attrs: Vec<String>) {
+        self.edges.push((from, to, attrs));
+    }
+}
+
+impl ToD3 for Recipe {
+    fn to_d3(&self) -> D3Graph {
+        D3Graph::default()
+    }
+}
+
+impl ToD3 for Ibis {
+    fn to_d3(&self) -> D3Graph {
+        D3Graph::default()
+    }
+}

--- a/ibis/src/d3.rs
+++ b/ibis/src/d3.rs
@@ -3,8 +3,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
+use crate::recipes::{Ibis, Recipe};
 use serde::{Deserialize, Serialize};
-use crate::recipes::{Recipe, Ibis};
 
 #[derive(Default, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde()]

--- a/ibis/src/lib.rs
+++ b/ibis/src/lib.rs
@@ -64,6 +64,14 @@ macro_rules! name {
     };
 }
 
+pub fn run_ibis(data: &str) -> Ibis {
+    get_solutions(data, Some(0))
+}
+
+pub fn all_solutions(data: &str) -> Ibis {
+    get_solutions(data, None)
+}
+
 pub fn get_solutions(data: &str, loss: Option<usize>) -> Ibis {
     let mut runtime = Ibis::new();
 
@@ -102,9 +110,9 @@ pub mod wasm {
     }
 
     #[wasm_bindgen]
-    pub fn best_solutions(data: &str) -> String {
+    pub fn run_ibis(data: &str) -> String {
         setup();
-        let solutions = super::best_solutions(data);
+        let solutions = super::run_ibis(data);
         serde_json::to_string(&solutions).expect("Couldn't serialize Ibis output")
     }
 
@@ -114,12 +122,4 @@ pub mod wasm {
         let solutions = super::all_solutions(data);
         serde_json::to_string(&solutions).expect("Couldn't serialize Ibis output")
     }
-}
-
-pub fn best_solutions(data: &str) -> Ibis {
-    get_solutions(data, Some(0))
-}
-
-pub fn all_solutions(data: &str) -> Ibis {
-    get_solutions(data, None)
 }

--- a/ibis/src/lib.rs
+++ b/ibis/src/lib.rs
@@ -17,6 +17,8 @@ mod type_struct;
 mod util;
 #[cfg(feature = "dot")]
 pub mod dot;
+#[cfg(feature = "d3")]
+pub mod d3;
 pub mod recipes;
 #[cfg(feature = "dot")]
 pub mod to_dot_impls;

--- a/ibis/src/lib.rs
+++ b/ibis/src/lib.rs
@@ -15,10 +15,10 @@ mod type_parser_cache;
 mod type_struct;
 #[macro_use]
 mod util;
-#[cfg(feature = "dot")]
-pub mod dot;
 #[cfg(feature = "d3")]
 pub mod d3;
+#[cfg(feature = "dot")]
+pub mod dot;
 pub mod recipes;
 #[cfg(feature = "dot")]
 pub mod to_dot_impls;

--- a/ibis/src/lib.rs
+++ b/ibis/src/lib.rs
@@ -102,52 +102,24 @@ pub mod wasm {
     }
 
     #[wasm_bindgen]
-    pub fn best_solutions_to_json(data: &str) -> String {
+    pub fn best_solutions(data: &str) -> String {
         setup();
-        super::best_solutions_to_json(data)
+        let solutions = super::best_solutions(data);
+        serde_json::to_string(&solutions).expect("Couldn't serialize Ibis output")
     }
 
     #[wasm_bindgen]
-    pub fn all_solutions_to_json(data: &str) -> String {
+    pub fn all_solutions(data: &str) -> String {
         setup();
-        super::all_solutions_to_json(data)
-    }
-
-    #[cfg(feature = "dot")]
-    #[wasm_bindgen]
-    pub fn best_solutions_to_dot(data: &str) -> String {
-        setup();
-        super::best_solutions_to_dot(data)
-    }
-
-    #[cfg(feature = "dot")]
-    #[wasm_bindgen]
-    pub fn all_solutions_to_dot(data: &str) -> String {
-        setup();
-        super::all_solutions_to_dot(data)
+        let solutions = super::all_solutions(data);
+        serde_json::to_string(&solutions).expect("Couldn't serialize Ibis output")
     }
 }
 
-pub fn best_solutions_to_json(data: &str) -> String {
-    let solutions = get_solutions(data, Some(0));
-    serde_json::to_string(&solutions).expect("Couldn't serialize Ibis output")
+pub fn best_solutions(data: &str) -> Ibis {
+    get_solutions(data, Some(0))
 }
 
-pub fn all_solutions_to_json(data: &str) -> String {
-    let solutions = get_solutions(data, None);
-    serde_json::to_string(&solutions).expect("Couldn't serialize Ibis output")
-}
-
-#[cfg(feature = "dot")]
-pub fn best_solutions_to_dot(data: &str) -> String {
-    use dot::ToDot;
-    let solutions = get_solutions(data, Some(0));
-    solutions.to_dot()
-}
-
-#[cfg(feature = "dot")]
-pub fn all_solutions_to_dot(data: &str) -> String {
-    use dot::ToDot;
-    let solutions = get_solutions(data, None);
-    solutions.to_dot()
+pub fn all_solutions(data: &str) -> Ibis {
+    get_solutions(data, None)
 }

--- a/ibis/src/recipes.rs
+++ b/ibis/src/recipes.rs
@@ -517,11 +517,8 @@ impl Ibis {
                 .extend(recipe.trusted_to_remove_tag_from_node);
         }
 
-        let d3_output = self.config.flags.get(D3_OUTPUT).cloned();
-        let dot_output = self.config.flags.get(DOT_OUTPUT).cloned();
-
         let mut result = Ibis {
-            config: self.config,
+            config: self.config.clone(),
             num_unchecked_solutions: unchecked_solutions.len(),
             num_solutions: solutions.len(),
             num_selected: recipes.len(),
@@ -533,14 +530,14 @@ impl Ibis {
         };
 
         #[cfg(feature = "d3")]
-        if let Some(true) = d3_output {
+        if let Some(true) = self.config.flags.get(D3_OUTPUT).cloned() {
             // Generate the d3 output
             use crate::d3::ToD3;
             result.d3_output = Some(result.to_d3());
         }
 
         #[cfg(feature = "dot")]
-        if let Some(true) = dot_output {
+        if let Some(true) = self.config.flags.get(DOT_OUTPUT) {
             // Generate the dot output
             use crate::dot::ToDot;
             result.dot_output = Some(result.to_dot());

--- a/ibis/src/recipes.rs
+++ b/ibis/src/recipes.rs
@@ -249,7 +249,9 @@ fn is_default<T: Default + Eq>(v: &T) -> bool {
 }
 
 const PLANNING: &str = "planning";
-const FLAGS: &[&str] = &[PLANNING];
+const D3_OUTPUT: &str = "d3";
+const DOT_OUTPUT: &str = "dot";
+const FLAGS: &[&str] = &[PLANNING, D3_OUTPUT, DOT_OUTPUT];
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -296,6 +298,10 @@ pub struct Ibis {
     pub num_solutions: usize,
     #[serde(default, skip_serializing_if = "is_default")]
     pub num_selected: usize,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub d3_output: Option<crate::d3::D3Graph>,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub dot_output: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
@@ -383,10 +389,12 @@ impl Ibis {
                     flags,
                 },
             mut recipes, // Mutation required to move rather than copy the data.
+            shared,
             num_unchecked_solutions: _,
             num_solutions: _,
             num_selected: _,
-            shared,
+            d3_output: _,
+            dot_output: _,
         } = recipes;
         self.config.flags = flags; // TODO: Merge not overwrite.
         self.config.subtypes.extend(subtypes);
@@ -508,13 +516,36 @@ impl Ibis {
                 .trusted_to_remove_tag_from_node
                 .extend(recipe.trusted_to_remove_tag_from_node);
         }
-        Ibis {
+
+        let d3_output = self.config.flags.get(D3_OUTPUT).cloned();
+        let dot_output = self.config.flags.get(DOT_OUTPUT).cloned();
+
+        let mut result = Ibis {
             config: self.config,
             num_unchecked_solutions: unchecked_solutions.len(),
             num_solutions: solutions.len(),
             num_selected: recipes.len(),
             recipes,
             shared,
+            // '_output's are unused unless requested
+            d3_output: None,
+            dot_output: None,
+        };
+
+        #[cfg(feature = "d3")]
+        if let Some(true) = d3_output {
+            // Generate the d3 output
+            use crate::d3::ToD3;
+            result.d3_output = Some(result.to_d3());
         }
+
+        #[cfg(feature = "dot")]
+        if let Some(true) = dot_output {
+            // Generate the dot output
+            use crate::dot::ToDot;
+            result.dot_output = Some(result.to_dot());
+        }
+
+        result
     }
 }

--- a/ibis/src/recipes.rs
+++ b/ibis/src/recipes.rs
@@ -412,7 +412,7 @@ impl Ibis {
                 runtime.extend(&[FlagEnabled(flag, *value)]);
             } else {
                 warnings.push(format!(
-                    "Unknown flag '{}' set to: '{}'. Known flags are {}",
+                    "Unknown flag '{}' set to: {:?}. Known flags are {}",
                     key,
                     value,
                     FLAGS.join(", ")

--- a/ibis/src/recipes.rs
+++ b/ibis/src/recipes.rs
@@ -412,7 +412,7 @@ impl Ibis {
                 runtime.extend(&[FlagEnabled(flag, *value)]);
             } else {
                 warnings.push(format!(
-                    "Unknown flag {:?} set to: {:?}. Known flags are {}",
+                    "Unknown flag '{}' set to: '{}'. Known flags are {}",
                     key,
                     value,
                     FLAGS.join(", ")

--- a/ibis/tests/flags.rs
+++ b/ibis/tests/flags.rs
@@ -23,7 +23,7 @@ fn unknown_flag_generates_warning() {
         .warnings
         .get(0)
         .expect("Should have a single value");
-    let expected = r#"Unknown flag "unknown_and_unexpected_flag" set to: true"#;
+    let expected = r#"Unknown flag 'unknown_and_unexpected_flag' set to: true"#;
     assert!(
         warning.starts_with(expected),
         "unexpected warning:\n'{}'\n'{}'",


### PR DESCRIPTION
Clean up of the various ibis API functions to move almost everything into the flags/config parameters.

This makes using ibis simpler!

Rather than using a different function to get json/dot/d3 output, ibis can now be told to generate d3/dot when generating json, including them on the `d3_output` and `dot_output` fields respectively.

This also makes getting debug and graphical output at the same time faster (previously one run was needed for the debug output and another for the dot).